### PR TITLE
Logger

### DIFF
--- a/src/core/log.cppm
+++ b/src/core/log.cppm
@@ -5,87 +5,85 @@ module;
 #include <print>
 #include <source_location>
 #include <string_view>
-#include <functional>
 
 export module core.log;
 
 export namespace core::log {
 
-enum class Level : uint8_t { trace, debug, info, warn, error, critical, off };
+// ─────────────────── enums & helpers ───────────────────
+enum class Level : std::uint8_t { trace, debug, info, warn, error, critical, off };
 
-constexpr std::string_view to_string(const Level level) noexcept {
+[[nodiscard]] consteval std::string_view to_string(const Level level) noexcept {
     switch (level) {
-    case Level::trace:    return "TRACE";
-    case Level::debug:    return "DEBUG";
-    case Level::info:     return "INFO";
-    case Level::warn:     return "WARN";
-    case Level::error:    return "ERROR";
-    case Level::critical: return "CRIT";
-    default:              return "UNKNOWN";
+        case Level::trace:    return "TRACE";
+        case Level::debug:    return "DEBUG";
+        case Level::info:     return "INFO";
+        case Level::warn:     return "WARN";
+        case Level::error:    return "ERROR";
+        case Level::critical: return "CRIT";
+        default:              return "UNKNOWN";
     }
 }
 
-// Compile-time switch; set to Level::info (etc.) via a compile definition
-#ifndef ATTO_LOG_LEVEL
+// ──────────── compile-time verbosity switch ───────────
+#ifndef LOG_LEVEL
     inline constexpr auto compile_time_level = Level::info;
 #else
-    inline constexpr Level compile_time_level = static_cast<Level>(ATTO_LOG_LEVEL);
+    inline constexpr auto compile_time_level = static_cast<Level>(ATTO_LOG_LEVEL);
 #endif
 
-// Sink: defaults to std::print with stderr, but can be replaced later by a log file later
-inline std::function<void(std::string_view)> sink = [](std::string_view s) { std::print(stderr, "{}", s); };
+// ────── output sink (replace with file possible) ──────
+using Sink = void(*)(std::string_view);
+inline Sink sink = +[](std::string_view s){ std::print(stderr, "{}", s); };
 
-template<Level level, typename... Args>
+// ─────────────────── core formatter ───────────────────
+template<Level level, class... Args>
 constexpr void log(
-        const std::string_view fmt,
-        Args&&... args,
-        const std::source_location loc = std::source_location::current()
+        std::format_string<Args...> fmt,
+        Args&&...                   args
 ) {
-    if constexpr (level < compile_time_level) { return; }   // compiled out
+    if constexpr (level < compile_time_level) return;   // fully removed at compile time if unneeded
 
-    using clock         = std::chrono::steady_clock;
-    const auto now      = clock::now().time_since_epoch();
-    const auto millis   = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+    const std::source_location  loc = std::source_location::current();
+
+    using clock = std::chrono::steady_clock;
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(clock::now().time_since_epoch()).count();
 
     auto header = std::format(
             "[{:>10} ms] [{:^7}] {:>20}:{:<3} ",
-            millis,
+            ms,
             to_string(level),
-            loc.file_name(), loc.line()
+            loc.file_name(),
+            loc.line()
     );
 
-    auto body = std::vformat(fmt, std::make_format_args(args...));
+    auto body = std::format(fmt, std::forward<Args>(args)...);
     sink(std::format("{}{}\n", header, body));
 }
 
-template<typename... A>
-constexpr void trace(std::string_view f, A&&... a, std::source_location loc = std::source_location::current()) {
-    log<Level::trace>(f, std::forward<A>(a)..., loc);
-}
+// ──────────────── convenience wrappers ────────────────
+template<class... A>
+constexpr void trace   (std::format_string<A...> f, A&&... a)
+{ log<Level::trace   >(f, std::forward<A>(a)...); }
 
-template<typename... A>
-constexpr void debug(std::string_view f, A&&... a, std::source_location loc = std::source_location::current()) {
-    log<Level::debug>(f, std::forward<A>(a)..., loc);
-}
+template<class... A>
+constexpr void debug   (std::format_string<A...> f, A&&... a)
+{ log<Level::debug   >(f, std::forward<A>(a)...); }
 
-template<typename... A>
-constexpr void info(std::string_view f, A&&... a, std::source_location loc = std::source_location::current()) {
-    log<Level::info>(f, std::forward<A>(a)..., loc);
-}
+template<class... A>
+constexpr void info    (std::format_string<A...> f, A&&... a)
+{ log<Level::info    >(f, std::forward<A>(a)...); }
 
-template<typename... A>
-constexpr void warn(std::string_view f, A&&... a, std::source_location loc = std::source_location::current()) {
-    log<Level::warn>(f, std::forward<A>(a)..., loc);
-}
+template<class... A>
+constexpr void warn    (std::format_string<A...> f, A&&... a)
+{ log<Level::warn    >(f, std::forward<A>(a)...); }
 
-template<typename... A>
-constexpr void error(std::string_view f, A&&... a, std::source_location loc = std::source_location::current()) {
-    log<Level::error>(f, std::forward<A>(a)..., loc);
-}
+template<class... A>
+constexpr void error   (std::format_string<A...> f, A&&... a)
+{ log<Level::error   >(f, std::forward<A>(a)...); }
 
-template<typename... A>
-constexpr void critical(std::string_view f, A&&... a, std::source_location loc = std::source_location::current()) {
-    log<Level::critical>(f, std::forward<A>(a)..., loc);
-}
+template<class... A>
+constexpr void critical(std::format_string<A...> f, A&&... a)
+{ log<Level::critical>(f, std::forward<A>(a)...); }
 
 } // namespace core::log

--- a/src/core/log.cppm
+++ b/src/core/log.cppm
@@ -29,7 +29,7 @@ enum class Level : std::uint8_t { trace, debug, info, warn, error, critical, off
 #ifndef LOG_LEVEL
     inline constexpr auto compile_time_level = Level::info;
 #else
-    inline constexpr auto compile_time_level = static_cast<Level>(ATTO_LOG_LEVEL);
+    inline constexpr auto compile_time_level = static_cast<Level>(LOG_LEVEL);
 #endif
 
 // ────── output sink (replace with file possible) ──────
@@ -44,17 +44,13 @@ constexpr void log(
 ) {
     if constexpr (level < compile_time_level) return;   // fully removed at compile time if unneeded
 
-    const std::source_location  loc = std::source_location::current();
-
     using clock = std::chrono::steady_clock;
     auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(clock::now().time_since_epoch()).count();
 
     auto header = std::format(
-            "[{:>10} ms] [{:^7}] {:>20}:{:<3} ",
+            "[{:>10} ms] [{:^7}] ",
             ms,
-            to_string(level),
-            loc.file_name(),
-            loc.line()
+            to_string(level)
     );
 
     auto body = std::format(fmt, std::forward<Args>(args)...);

--- a/src/core/log.cppm
+++ b/src/core/log.cppm
@@ -1,0 +1,91 @@
+module;
+
+#include <chrono>
+#include <format>
+#include <print>
+#include <source_location>
+#include <string_view>
+#include <functional>
+
+export module core.log;
+
+export namespace core::log {
+
+enum class Level : uint8_t { trace, debug, info, warn, error, critical, off };
+
+constexpr std::string_view to_string(const Level level) noexcept {
+    switch (level) {
+    case Level::trace:    return "TRACE";
+    case Level::debug:    return "DEBUG";
+    case Level::info:     return "INFO";
+    case Level::warn:     return "WARN";
+    case Level::error:    return "ERROR";
+    case Level::critical: return "CRIT";
+    default:              return "UNKNOWN";
+    }
+}
+
+// Compile-time switch; set to Level::info (etc.) via a compile definition
+#ifndef ATTO_LOG_LEVEL
+    inline constexpr auto compile_time_level = Level::info;
+#else
+    inline constexpr Level compile_time_level = static_cast<Level>(ATTO_LOG_LEVEL);
+#endif
+
+// Sink: defaults to std::print with stderr, but can be replaced later by a log file later
+inline std::function<void(std::string_view)> sink = [](std::string_view s) { std::print(stderr, "{}", s); };
+
+template<Level level, typename... Args>
+constexpr void log(
+        const std::string_view fmt,
+        Args&&... args,
+        const std::source_location loc = std::source_location::current()
+) {
+    if constexpr (level < compile_time_level) { return; }   // compiled out
+
+    using clock         = std::chrono::steady_clock;
+    const auto now      = clock::now().time_since_epoch();
+    const auto millis   = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+
+    auto header = std::format(
+            "[{:>10} ms] [{:^7}] {:>20}:{:<3} ",
+            millis,
+            to_string(level),
+            loc.file_name(), loc.line()
+    );
+
+    auto body = std::vformat(fmt, std::make_format_args(args...));
+    sink(std::format("{}{}\n", header, body));
+}
+
+template<typename... A>
+constexpr void trace(std::string_view f, A&&... a, std::source_location loc = std::source_location::current()) {
+    log<Level::trace>(f, std::forward<A>(a)..., loc);
+}
+
+template<typename... A>
+constexpr void debug(std::string_view f, A&&... a, std::source_location loc = std::source_location::current()) {
+    log<Level::debug>(f, std::forward<A>(a)..., loc);
+}
+
+template<typename... A>
+constexpr void info(std::string_view f, A&&... a, std::source_location loc = std::source_location::current()) {
+    log<Level::info>(f, std::forward<A>(a)..., loc);
+}
+
+template<typename... A>
+constexpr void warn(std::string_view f, A&&... a, std::source_location loc = std::source_location::current()) {
+    log<Level::warn>(f, std::forward<A>(a)..., loc);
+}
+
+template<typename... A>
+constexpr void error(std::string_view f, A&&... a, std::source_location loc = std::source_location::current()) {
+    log<Level::error>(f, std::forward<A>(a)..., loc);
+}
+
+template<typename... A>
+constexpr void critical(std::string_view f, A&&... a, std::source_location loc = std::source_location::current()) {
+    log<Level::critical>(f, std::forward<A>(a)..., loc);
+}
+
+} // namespace core::log


### PR DESCRIPTION
Added simple logging. Its not the fantastically optimized spdlog, but it works well and it doesn't require us to try and import a new library.

After importing `core.log`, use with `core::logger::trace/debug/info/warn/error/critical()`. 

Works like `std::print`. Log level is set at compile time and unused log levels are compiled out.